### PR TITLE
Add admin-only game management

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ node server.js
 
 Open `http://<raspberry-pi>:3000` in your browser to create or join games.
 
+### Admin Login
+
+Creating or managing games requires logging in with the admin password `1234`.
+Use the login form on the main page to obtain a token before creating games.
+
 ### Exposing on port 80
 
 To use the site with just the Pi's host name (no `:3000` suffix), run the

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,14 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+<h1>Admin Login</h1>
+<form id="login-form">
+    <label>Password
+        <input name="password" type="password" required>
+    </label>
+    <button type="submit">Login</button>
+</form>
+<div id="login-status" class="result"></div>
 <h1>Create Game</h1>
 <form id="create-form">
     <label>Starting Stack
@@ -41,12 +49,32 @@
 <h1>Available Games</h1>
 <ul id="games" class="game-list"></ul>
 <script>
+const loginForm = document.getElementById('login-form');
+const loginStatus = document.getElementById('login-status');
+let adminToken = localStorage.getItem('adminToken');
+if(adminToken){
+    loginStatus.textContent = 'Logged in';
+}
+loginForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(loginForm));
+    const res = await fetch('/api/login', {method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({password:data.password})});
+    const out = await res.json();
+    if(out.token){
+        adminToken = out.token;
+        localStorage.setItem('adminToken', adminToken);
+        loginStatus.textContent = 'Logged in';
+    } else if(out.error){
+        alert(out.error);
+    }
+});
 const createForm = document.getElementById('create-form');
 createForm.addEventListener('submit', async e => {
     e.preventDefault();
     const data = Object.fromEntries(new FormData(createForm));
     data.levels = JSON.parse(data.levels);
-    const res = await fetch('/api/create', {method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});
+    if(!adminToken){ alert('Admin login required'); return; }
+    const res = await fetch('/api/create', {method:'POST',headers:{'Content-Type':'application/json','Authorization':adminToken},body:JSON.stringify(data)});
     const out = await res.json();
     document.getElementById('result').textContent = 'Game code: '+out.code;
 });


### PR DESCRIPTION
## Summary
- add admin login with hard-coded password `1234`
- enforce admin authentication for creating games and modifying state
- prevent admin from joining games
- add admin login form to the UI
- document the login requirement in README

## Testing
- `npm test` *(fails: Missing script)*
- `node server/server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6866b9be540c832baa9473a0e4f5f7a1